### PR TITLE
Fix peer dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "typescript-eslint": "^8.4.0"
       },
       "peerDependencies": {
-        "@playwright/test": "^1.10.0"
+        "@playwright/test": "^1.37.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "package-lock.json"
   ],
   "peerDependencies": {
-    "@playwright/test": "^1.10.0"
+    "@playwright/test": "^1.37.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.10.0",


### PR DESCRIPTION
## Summary
- require Playwright 1.37+ in peerDependencies

## Testing
- `npm test` *(fails: playwright not found)*
- `npm run lint:check` *(fails: ESLint config missing globals)*
- `npm run format:check`

------
https://chatgpt.com/codex/tasks/task_b_683815cce2248325ba542378ee111705