### PR TITLE
fix: upload with playwright version

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -101,6 +101,8 @@ class ReporterPlaywrightReportsServer implements Reporter {
       Object.entries(this.rpOptions.resultDetails).map(([key, value]) => [key, value ?? '']),
     );
 
+    const version = this.pwConfig.version ?? '';
+
     const url = this.rpOptions.url.endsWith('/') ? this.rpOptions.url.slice(0, -1) : this.rpOptions.url;
     const shard = this.pwConfig.shard;
 
@@ -119,6 +121,7 @@ class ReporterPlaywrightReportsServer implements Reporter {
         ...clearedResDetails,
         ...(shard ? { shardCurrent: shard.current, shardTotal: shard.total } : {}),
         triggerReportGeneration: this.rpOptions.triggerReportGeneration,
+        playwrightVersion: version,
       },
     });
 
@@ -145,6 +148,7 @@ class ReporterPlaywrightReportsServer implements Reporter {
             data: {
               resultsIds: [resultResponse.resultID],
               ...clearedResDetails,
+              playwrightVersion: version,
             },
           })
         ).json();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cyborgtests/reporter-playwright-reports-server",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cyborgtests/reporter-playwright-reports-server",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyborgtests/reporter-playwright-reports-server",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Reporter that uploads your blob reports to playwright reports server https://github.com/CyborgTests/playwright-reports-server",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
### Added
- upload and generate report payload metadata must include playwright version to handle report generation on server side. Required for https://github.com/CyborgTests/playwright-reports-server/issues/91